### PR TITLE
rootdir: init.rc: Fix for "add_tid_to_cgroup failed to write" warnings

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -148,6 +148,7 @@ on init
     mkdir /dev/cpuctl
     mount cgroup none /dev/cpuctl cpu
     chown system system /dev/cpuctl
+    chmod 0660 /dev/cpuctl
     chown system system /dev/cpuctl/tasks
     chmod 0666 /dev/cpuctl/tasks
     write /dev/cpuctl/cpu.rt_period_us 1000000


### PR DESCRIPTION
Logcat is full of warnings like:

 W/SchedPolicy( 2013): add_tid_to_cgroup failed to write '2371' (Permission denied); policy=1

This is fixed by giving /dev/cpuctl group write permissions, which was
surely the original intention of the init.rc setup as this is done for
the sub-directories it creates.

This fixes bug launchpad bug #1037611

Change-Id: I47ff539ef4dd9922aba0be67dbf8bd4f0a234163
Signed-off-by: Jon Medhurst <tixy@linaro.org>