### PR TITLE
init: Don't update recovery on boot

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -685,6 +685,6 @@ service flash_recovery /system/bin/install-recovery.sh
     disabled
 
 # update recovery if enabled
-on property:persist.sys.recovery_update=true
-    start flash_recovery
+#on property:persist.sys.recovery_update=true
+#    start flash_recovery
 


### PR DESCRIPTION
Our recovery is not ready yet, so don't replace the image even
if persist.sys.recovery_update is set to true.

Change-Id: I406deb4c53836da4c4c6f44933154804ece1d1a7